### PR TITLE
Update requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ async def on_message(message):
                 logger.info(f"{message.id}: deeplx api returned status code {deeplx_translate.status_code}, falling back to gtranslate")
                 logger.info(f"{message.id}: deeplx api text output: {deeplx_translate.text}")
 
-            if translated == message_text.capitalize():
+            if translated == message_text or translated == message_text.capitalize():
                 logger.info(f"{message.id}: translation not needed")
                 return
 

--- a/main.py
+++ b/main.py
@@ -94,6 +94,10 @@ async def on_message(message):
                 logger.info(f"{message.id}: deeplx api returned status code {deeplx_translate.status_code}, falling back to gtranslate")
                 logger.info(f"{message.id}: deeplx api text output: {deeplx_translate.text}")
 
+            if translated == message_text.capitalize():
+                logger.info(f"{message.id}: translation not needed")
+                return
+
             # chr(10) returns the \n character, f-strings in python dont allow backslashes in the brace substitution parts
             formatted = f"{message_text}\n-# `{gtranslated.src} -> en` {translated.replace(chr(10), chr(10)+'-# ')}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py
 requests
 python-dotenv
-googletrans==3.1.0a0
+googletrans
 audioop-lts
 legacy-cgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ discord.py
 requests
 python-dotenv
 googletrans==3.1.0a0
+audioop-lts
+legacy-cgi


### PR DESCRIPTION
audioop and cgi were removied in Python 3.13 so you have to install a fork of them if you want to use them in Python versions above 3.12.

Without them gloykinator refuses to launch.